### PR TITLE
fix: Allow values or a Document to be used for pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,8 +347,10 @@ All the query options can be seen in the [API reference for Query](https://githu
 - `where` Comparative operations for filtering the query.
 - `from` Set by default for you to eb the current collection of the reference.
 - `orderBy` The field and direction to order by.
-- `startAt` A reference to a specific document from which to start the query.
-- `endAt` A reference to a specific document at which to end the query.
+- `startAt` A specific document, or values corresponding to the `orderBy` clause, from which to start the query.
+- `startAfter` A specific document, or values corresponding to the `orderBy` clause, from which to start the query after.
+- `endAt` A specific document, or values corresponding to the `orderBy` clause, from which to end the query.
+- `endAfter` A specific document, or values corresponding to the `orderBy` clause, from which to end the query after.
 - `offset` Number of results to skip
 - `limit` The maximum number of documents to return.
 

--- a/test/Query.test.js
+++ b/test/Query.test.js
@@ -301,6 +301,12 @@ describe('Query', () => {
 						fieldPath: 'field.path'
 					},
 					direction: 'DESCENDING'
+				},
+				{
+					field: {
+						fieldPath: '__name__'
+					},
+					direction: 'DESCENDING'
 				}
 			];
 
@@ -317,6 +323,12 @@ describe('Query', () => {
 				{
 					field: {
 						fieldPath: 'field.path'
+					},
+					direction: 'ASCENDING'
+				},
+				{
+					field: {
+						fieldPath: '__name__'
 					},
 					direction: 'ASCENDING'
 				}
@@ -352,6 +364,12 @@ describe('Query', () => {
 						fieldPath: 'second.path'
 					},
 					direction: 'DESCENDING'
+				},
+				{
+					field: {
+						fieldPath: '__name__'
+					},
+					direction: 'DESCENDING'
 				}
 			];
 
@@ -374,6 +392,12 @@ describe('Query', () => {
 				{
 					field: {
 						fieldPath: 'second.path'
+					},
+					direction: 'ASCENDING'
+				},
+				{
+					field: {
+						fieldPath: '__name__'
 					},
 					direction: 'ASCENDING'
 				}
@@ -425,7 +449,8 @@ describe('Query', () => {
 			const expected = {
 				values: [
 					{ stringValue: 'Hi!' },
-					{ booleanValue: false }
+					{ booleanValue: false },
+					{ referenceValue: rawDoc.name }
 				],
 				before: true
 			};
@@ -484,7 +509,8 @@ describe('Query', () => {
 			const expected = {
 				values: [
 					{ stringValue: 'Hi!' },
-					{ booleanValue: false }
+					{ booleanValue: false },
+					{ referenceValue: rawDoc.name }
 				],
 				before: false
 			};
@@ -543,7 +569,8 @@ describe('Query', () => {
 			const expected = {
 				values: [
 					{ stringValue: 'Hi!' },
-					{ booleanValue: false }
+					{ booleanValue: false },
+					{ referenceValue: rawDoc.name }
 				],
 				before: true
 			};
@@ -602,7 +629,8 @@ describe('Query', () => {
 			const expected = {
 				values: [
 					{ stringValue: 'Hi!' },
-					{ booleanValue: false }
+					{ booleanValue: false },
+					{ referenceValue: rawDoc.name }
 				],
 				before: false
 			};

--- a/test/Query.test.js
+++ b/test/Query.test.js
@@ -6,6 +6,23 @@ import { Document } from '../src/Document';
 const db = new Database({ projectId: 'projectId' });
 const colRef = db.ref('col');
 
+const rawDoc = {
+	name: 'projects/projectId/databases/(default)/documents/public/types',
+	fields: {
+		one: {
+			stringValue: 'Hi!'
+		},
+		two: {
+			booleanValue: false
+		},
+		three: {
+			integerValue: '42'
+		}
+	},
+	createTime: '2019-10-10T14:00:00.617973Z',
+	updateTime: '2019-10-10T14:44:42.885653Z'
+};
+
 describe('Query', () => {
 	describe('select', () => {
 		test('Valid arguments', () => {
@@ -382,18 +399,33 @@ describe('Query', () => {
 
 	describe('startAt', () => {
 		test('Valid arguments', () => {
-			const docRef = new Reference('col/doc', db);
-
 			const query = new Query({
 				from: colRef,
-				startAt: docRef
+				startAt: ['abc', 123]
 			});
 
 			const expected = {
 				values: [
-					{
-						referenceValue: docRef.name
-					}
+					{ stringValue: 'abc' },
+					{ integerValue: '123' }
+				],
+				before: true
+			};
+
+			expect(query.toJSON().structuredQuery.startAt).toEqual(expected);
+		});
+
+		test('Document as cursor', () => {
+			const query = new Query({
+				from: colRef,
+				orderBy: ['one', 'two'],
+				startAt: new Document(rawDoc, db)
+			});
+
+			const expected = {
+				values: [
+					{ stringValue: 'Hi!' },
+					{ booleanValue: false }
 				],
 				before: true
 			};
@@ -405,28 +437,113 @@ describe('Query', () => {
 			expect(() => {
 				new Query({
 					from: colRef,
-					startAt: 42
+					startAt: []
 				});
 			}).toThrow(
-				'Invalid argument "startAt": Expected a reference to a document'
+				'Invalid argument "startAt": Expected at least one value'
+			);
+		});
+
+		test('Document without orderBy', () => {
+			expect(() => {
+				new Query({
+					from: colRef,
+					startAt: new Document(rawDoc, db)
+				});
+			}).toThrow(
+				'Invalid argument "startAt": Cannot use document for cursor without orderBy set'
+			);
+		});
+	});
+
+	describe('startAfter', () => {
+		test('Valid arguments', () => {
+			const query = new Query({
+				from: colRef,
+				startAfter: ['abc', 123]
+			});
+
+			const expected = {
+				values: [
+					{ stringValue: 'abc' },
+					{ integerValue: '123' }
+				],
+				before: false
+			};
+
+			expect(query.toJSON().structuredQuery.startAt).toEqual(expected);
+		});
+
+		test('Document as cursor', () => {
+			const query = new Query({
+				from: colRef,
+				orderBy: ['one', 'two'],
+				startAfter: new Document(rawDoc, db)
+			});
+
+			const expected = {
+				values: [
+					{ stringValue: 'Hi!' },
+					{ booleanValue: false }
+				],
+				before: false
+			};
+
+			expect(query.toJSON().structuredQuery.startAt).toEqual(expected);
+		});
+
+		test('Invalid arguments', () => {
+			expect(() => {
+				new Query({
+					from: colRef,
+					startAfter: []
+				});
+			}).toThrow(
+				'Invalid argument "startAfter": Expected at least one value'
+			);
+		});
+
+		test('Document without orderBy', () => {
+			expect(() => {
+				new Query({
+					from: colRef,
+					startAfter: new Document(rawDoc, db)
+				});
+			}).toThrow(
+				'Invalid argument "startAfter": Cannot use document for cursor without orderBy set'
 			);
 		});
 	});
 
 	describe('endAt', () => {
 		test('Valid arguments', () => {
-			const docRef = new Reference('col/doc', db);
-
 			const query = new Query({
 				from: colRef,
-				endAt: docRef
+				endAt: ['abc', 123]
 			});
 
 			const expected = {
 				values: [
-					{
-						referenceValue: docRef.name
-					}
+					{ stringValue: 'abc' },
+					{ integerValue: '123' }
+				],
+				before: true
+			};
+
+			expect(query.toJSON().structuredQuery.endAt).toEqual(expected);
+		});
+
+		test('Document as cursor', () => {
+			const query = new Query({
+				from: colRef,
+				orderBy: ['one', 'two'],
+				endAt: new Document(rawDoc, db)
+			});
+
+			const expected = {
+				values: [
+					{ stringValue: 'Hi!' },
+					{ booleanValue: false }
 				],
 				before: true
 			};
@@ -438,10 +555,80 @@ describe('Query', () => {
 			expect(() => {
 				new Query({
 					from: colRef,
-					endAt: 42
+					endAt: []
 				});
 			}).toThrow(
-				'Invalid argument "endAt": Expected a reference to a document'
+				'Invalid argument "endAt": Expected at least one value'
+			);
+		});
+
+		test('Document without orderBy', () => {
+			expect(() => {
+				new Query({
+					from: colRef,
+					endAt: new Document(rawDoc, db)
+				});
+			}).toThrow(
+				'Invalid argument "endAt": Cannot use document for cursor without orderBy set'
+			);
+		});
+	});
+
+	describe('endAfter', () => {
+		test('Valid arguments', () => {
+			const query = new Query({
+				from: colRef,
+				endAfter: ['abc', 123]
+			});
+
+			const expected = {
+				values: [
+					{ stringValue: 'abc' },
+					{ integerValue: '123' }
+				],
+				before: false
+			};
+
+			expect(query.toJSON().structuredQuery.endAt).toEqual(expected);
+		});
+
+		test('Document as cursor', () => {
+			const query = new Query({
+				from: colRef,
+				orderBy: ['one', 'two'],
+				endAfter: new Document(rawDoc, db)
+			});
+
+			const expected = {
+				values: [
+					{ stringValue: 'Hi!' },
+					{ booleanValue: false }
+				],
+				before: false
+			};
+
+			expect(query.toJSON().structuredQuery.endAt).toEqual(expected);
+		});
+
+		test('Invalid arguments', () => {
+			expect(() => {
+				new Query({
+					from: colRef,
+					endAfter: []
+				});
+			}).toThrow(
+				'Invalid argument "endAfter": Expected at least one value'
+			);
+		});
+
+		test('Document without orderBy', () => {
+			expect(() => {
+				new Query({
+					from: colRef,
+					endAfter: new Document(rawDoc, db)
+				});
+			}).toThrow(
+				'Invalid argument "endAfter": Cannot use document for cursor without orderBy set'
 			);
 		});
 	});


### PR DESCRIPTION
Changes `startAt` and `endAt` to accept field values or a concrete `Document` and adds `startAfter` and `endAfter`.

These functions can be passed values corresponding to the orderBy clause (same as official firebase sdk):
```js
db.ref('collection')
  .query()
  .orderBy('myString')
  .orderBy('myNum')
  .startAt('abc', 123);
// or
db.ref('collection')
  .query({
    orderBy: ['myString', 'myNum'],
    startAt: ['abc', 123]
  });
```

Or a concrete document from which the appropriate values are extracted (same as official firebase sdk):
```js
const doc = await db.ref('collection/doc').get();

db.ref('collection')
  .query()
  .orderBy('myString')
  .orderBy('myNum')
  .startAt(doc);
// or
db.ref('collection')
  .query({
    orderBy: ['myString', 'myNum'],
    startAt: doc
  });
```

Fixes #38.