### PR TITLE
fix: mask type definition in Reference

### DIFF
--- a/src/Reference.ts
+++ b/src/Reference.ts
@@ -12,7 +12,7 @@ export interface CrudOptions {
 	 */
 	updateMask?: boolean;
 	/** An array of the key paths to return back after the operation */
-	mask?: string[];
+	mask?: { fieldPaths: string[] };
 	/**
 	 * When set to true, the target document must exist.
 	 * When set to false, the target document must not exist.


### PR DESCRIPTION
Thank you for such a great library :tada:

In firebase doc, `mask` query parameter should be `DocumentMask`(you can see at [this page](https://firebase.google.com/docs/firestore/reference/rest/v1/projects.databases.documents/get))

And, the type of `DocumentMask` is `{ fieldPaths: string[] }` ([this page](https://firebase.google.com/docs/firestore/reference/rest/v1/DocumentMask))

So, mask type should be `{ fieldPaths: string[] }`, but now you define `string[]`.

I used the following code to confirm that it works.
```js
// In posts collection, there is a document `documentID: post1, data: { a: 1, b: 2, secret: 3 }`
db.ref('posts/post1').get({ mask: { fieldPaths: ['a', 'b'] } }) // OK
db.ref('posts/post1').get({ mask: ['a', 'b'] }) // Error: Invalid JSON payload received. Unknown name "mask": Cannot bind query parameter. 'mask' is a message type.
```

I'm not very good at writing test code, so sorry for the lack of jest tests in this pull request.